### PR TITLE
Fix for lvm-dependent tests and clear textbox

### DIFF
--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -166,13 +166,6 @@ function validate_microservices() {
         "dataprep-multimodal-redis-transcript" \
         "dataprep-multimodal-redis"
 
-    echo "Data Prep with Generating Caption for Image"
-    validate_service \
-        "${DATAPREP_GEN_CAPTION_SERVICE_ENDPOINT}" \
-        "Data preparation succeeded" \
-        "dataprep-multimodal-redis-caption" \
-        "dataprep-multimodal-redis"
-
     echo "Data Prep with Image & Caption Ingestion"
     validate_service \
         "${DATAPREP_INGEST_SERVICE_ENDPOINT}" \
@@ -225,6 +218,14 @@ function validate_microservices() {
         "lvm-tgi" \
         "lvm-tgi" \
         '{"retrieved_docs": [], "initial_query": "What is this?", "top_n": 1, "metadata": [{"b64_img_str": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8/5+hnoEIwDiqkL4KAcT9GO0U4BxoAAAAAElFTkSuQmCC", "transcript_for_inference": "yellow image", "video_id": "8c7461df-b373-4a00-8696-9a2234359fe0", "time_of_frame_ms":"37000000", "source_video":"WeAreGoingOnBullrun_8c7461df-b373-4a00-8696-9a2234359fe0.mp4"}], "chat_template":"The caption of the image is: '\''{context}'\''. {question}"}'
+
+    # data prep requiring lvm
+    echo "Data Prep with Generating Caption for Image"
+    validate_service \
+        "${DATAPREP_GEN_CAPTION_SERVICE_ENDPOINT}" \
+        "Data preparation succeeded" \
+        "dataprep-multimodal-redis-caption" \
+        "dataprep-multimodal-redis"
 
     sleep 1m
 }

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -164,13 +164,6 @@ function validate_microservices() {
         "dataprep-multimodal-redis-transcript" \
         "dataprep-multimodal-redis"
 
-    echo "Data Prep with Generating Caption for Image"
-    validate_service \
-        "${DATAPREP_GEN_CAPTION_SERVICE_ENDPOINT}" \
-        "Data preparation succeeded" \
-        "dataprep-multimodal-redis-caption" \
-        "dataprep-multimodal-redis"
-
     echo "Data Prep with Image & Caption Ingestion"
     validate_service \
         "${DATAPREP_INGEST_SERVICE_ENDPOINT}" \
@@ -223,6 +216,14 @@ function validate_microservices() {
         "lvm-llava-svc" \
         "lvm-llava-svc" \
         '{"retrieved_docs": [], "initial_query": "What is this?", "top_n": 1, "metadata": [{"b64_img_str": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8/5+hnoEIwDiqkL4KAcT9GO0U4BxoAAAAAElFTkSuQmCC", "transcript_for_inference": "yellow image", "video_id": "8c7461df-b373-4a00-8696-9a2234359fe0", "time_of_frame_ms":"37000000", "source_video":"WeAreGoingOnBullrun_8c7461df-b373-4a00-8696-9a2234359fe0.mp4"}], "chat_template":"The caption of the image is: '\''{context}'\''. {question}"}'
+
+    # data prep requiring lvm
+    echo "Data Prep with Generating Caption for Image"
+    validate_service \
+        "${DATAPREP_GEN_CAPTION_SERVICE_ENDPOINT}" \
+        "Data preparation succeeded" \
+        "dataprep-multimodal-redis-caption" \
+        "dataprep-multimodal-redis"
 
     sleep 3m
 }

--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -50,7 +50,7 @@ def clear_history(state, request: gr.Request):
     if state.image and os.path.exists(state.image):
         os.remove(state.image)
     state = multimodalqna_conv.copy()
-    return (state, state.to_gradio_chatbot(), {}, None, None) + (disable_btn,) * 1
+    return (state, state.to_gradio_chatbot(), None, None, None) + (disable_btn,) * 1
 
 
 def add_text(state, text, request: gr.Request):


### PR DESCRIPTION
## Description

Reordered the new lvm-dependent tests so they execute last and fixed a text display error.

## Issues

[MultimodalQnA Audio & Image Enhancements RFC](https://github.com/opea-project/docs/pull/208)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

No new dependencies

## Tests

Checked that the tests pass when the lvm service is ready. If it doesn't pass in OPEA's CICD then we might have to remove the tests.
