### PR TITLE
Update MMQnA xeon test to wait for LVM to be ready

### DIFF
--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -199,7 +199,18 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    sleep 10s
+    echo "Wait for lvm-llava service to be ready"
+    max_retries=10
+    for i in $(seq $max_retries)
+    do
+        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0") 
+	if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
+            sleep 10s
+	else
+	    echo "lvm-llava service is ready"
+	    break
+	fi
+    done
 
     # llava server
     echo "Evaluating lvm-llava"


### PR DESCRIPTION
## Description

Test update to wait for the LVM to be ready when testing on Xeon for MMQnA

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Manual run on CLX
