### PR TITLE
Test update: Increase sleep to 3m to wait for LVM microservice to be ready

### DIFF
--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -43,7 +43,7 @@ function setup_env() {
     export LLAVA_SERVER_PORT=8399
     export LVM_ENDPOINT="http://${host_ip}:8399"
     export EMBEDDING_MODEL_ID="BridgeTower/bridgetower-large-itm-mlm-itc"
-    export LVM_MODEL_ID="llava-hf/llava-v1.6-vicuna-13b-hf"
+    export LVM_MODEL_ID="llava-hf/llava-v1.6-vicuna-7b-hf"
     export WHISPER_MODEL="base"
     export MM_EMBEDDING_SERVICE_HOST_IP=${host_ip}
     export MM_RETRIEVER_SERVICE_HOST_IP=${host_ip}
@@ -200,7 +200,7 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    sleep 10s
+    sleep 3m
 
     # llava server
     echo "Evaluating LLAVA tgi-gaudi"

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -199,24 +199,7 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    echo "Wait for lvm-llava service to be ready"
-    max_retries=10
-    for i in $(seq $max_retries)
-    do
-        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0")
-	if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
-            echo "The lvm-llava service is not ready yet, sleeping 30s..."
-            sleep 30s
-	else
-	    echo "lvm-llava service is ready"
-	    break
-	fi
-    done
-
-    if [[ $i -ge 10 ]]; then
-        echo "WARNING: Max retries reached when waiting for the lvm-llava service to be ready"
-        docker logs lvm-llava >> ${LOG_PATH}/lvm_llava_file.log
-    fi
+    sleep 3m
 
     # llava server
     echo "Evaluating lvm-llava"


### PR DESCRIPTION
## Description

This attempts to fix the failing test by simplifying the code to just increase the wait for the LVM to be ready and also change the Gaudi test to use the 7b llava model instead of 13b.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
