### PR TITLE
MMQnA doc update correcting ASR and whisper image names

### DIFF
--- a/MultimodalQnA/docker_compose/intel/cpu/xeon/README.md
+++ b/MultimodalQnA/docker_compose/intel/cpu/xeon/README.md
@@ -188,8 +188,8 @@ Then run the command `docker images`, you will have the following 11 Docker Imag
 2. `opea/lvm-llava-svc:latest`
 3. `opea/lvm-llava:latest`
 4. `opea/retriever-multimodal-redis:latest`
-5. `opea/whisper`
-6. `opea/asr`
+5. `opea/whisper:latest`
+6. `opea/asr:latest`
 7. `opea/redis-vector-db`
 8. `opea/embedding-multimodal:latest`
 9. `opea/embedding-multimodal-bridgetower:latest`

--- a/MultimodalQnA/docker_compose/intel/cpu/xeon/README.md
+++ b/MultimodalQnA/docker_compose/intel/cpu/xeon/README.md
@@ -188,8 +188,8 @@ Then run the command `docker images`, you will have the following 11 Docker Imag
 2. `opea/lvm-llava-svc:latest`
 3. `opea/lvm-llava:latest`
 4. `opea/retriever-multimodal-redis:latest`
-5. `opea/whisper-service`
-6. `opea/asr-service`
+5. `opea/whisper`
+6. `opea/asr`
 7. `opea/redis-vector-db`
 8. `opea/embedding-multimodal:latest`
 9. `opea/embedding-multimodal-bridgetower:latest`

--- a/MultimodalQnA/docker_compose/intel/hpu/gaudi/README.md
+++ b/MultimodalQnA/docker_compose/intel/hpu/gaudi/README.md
@@ -137,8 +137,8 @@ Then run the command `docker images`, you will have the following 11 Docker Imag
 2. `opea/lvm-tgi:latest`
 3. `ghcr.io/huggingface/tgi-gaudi:2.0.6`
 4. `opea/retriever-multimodal-redis:latest`
-5. `opea/whisper`
-6. `opea/asr`
+5. `opea/whisper:latest`
+6. `opea/asr:latest`
 7. `opea/redis-vector-db`
 8. `opea/embedding-multimodal:latest`
 9. `opea/embedding-multimodal-bridgetower:latest`

--- a/MultimodalQnA/docker_compose/intel/hpu/gaudi/README.md
+++ b/MultimodalQnA/docker_compose/intel/hpu/gaudi/README.md
@@ -137,8 +137,8 @@ Then run the command `docker images`, you will have the following 11 Docker Imag
 2. `opea/lvm-tgi:latest`
 3. `ghcr.io/huggingface/tgi-gaudi:2.0.6`
 4. `opea/retriever-multimodal-redis:latest`
-5. `opea/whisper-service`
-6. `opea/asr-service`
+5. `opea/whisper`
+6. `opea/asr`
 7. `opea/redis-vector-db`
 8. `opea/embedding-multimodal:latest`
 9. `opea/embedding-multimodal-bridgetower:latest`


### PR DESCRIPTION
## Description

This is a small doc update to fix the name of the images to match what I'm seeing after building the images
```
$ docker images
REPOSITORY                                                                           TAG         IMAGE ID       CREATED          SIZE
opea/asr                                                                             latest      69a970987919   10 minutes ago   2.18GB
opea/whisper                                                                         latest      531a4e6596ae   10 minutes ago   2.8GB
```

## Issues

This should be included with the audio query PR for [phase 2 of MMQnA enhancements](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

N/A
