### PR TITLE
Dynamic wait for lvm service in MultimodalQnA tests

### DIFF
--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -205,7 +205,7 @@ function validate_microservices() {
     max_retries=10
     for i in $(seq $max_retries)
     do
-        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://" || true)
+        lvm_logs=$(docker logs tgi-llava-gaudi-server 2>&1 | grep "Connected" || true)
         if [[ -z "$lvm_logs" ]]; then
             echo "The lvm-llava service is not ready yet, sleeping 30s..."
             sleep 30s

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -201,7 +201,24 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    sleep 3m
+    echo "Wait for lvm-llava service to be ready"
+    max_retries=10
+    for i in $(seq $max_retries)
+    do
+        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0")
+        if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
+            echo "The lvm-llava service is not ready yet, sleeping 30s..."
+            sleep 30s
+        else
+            echo "lvm-llava service is ready"
+            break
+        fi
+    done
+
+    if [[ $i -ge 10 ]]; then
+        echo "WARNING: Max retries reached when waiting for the lvm-llava service to be ready"
+        docker logs lvm-llava >> ${LOG_PATH}/lvm_llava_file.log
+    fi
 
     # llava server
     echo "Evaluating LLAVA tgi-gaudi"

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -205,8 +205,8 @@ function validate_microservices() {
     max_retries=10
     for i in $(seq $max_retries)
     do
-        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0")
-        if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
+        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://" || true)
+        if [[ -z "$lvm_logs" ]]; then
             echo "The lvm-llava service is not ready yet, sleeping 30s..."
             sleep 30s
         else

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -18,6 +18,24 @@ export image_fn="apple.png"
 export video_fn="WeAreGoingOnBullrun.mp4"
 export caption_fn="apple.txt"
 
+function check_service_ready() {
+    local container_name="$1"
+    local max_retries="$2"
+    local log_string="$3"
+
+    for i in $(seq 1 "$max_retries")
+    do
+        service_logs=$(docker logs "$container_name" 2>&1 | grep "$log_string" || true)
+        if [[ -z "$service_logs" ]]; then
+            echo "The $container_name service is not ready yet, sleeping 30s..."
+            sleep 30s
+        else
+            echo "$container_name service is ready"
+            break
+        fi
+    done
+}
+
 function build_docker_images() {
     cd $WORKPATH/docker_image_build
     git clone https://github.com/opea-project/GenAIComps.git && cd GenAIComps && git checkout "${opea_branch:-"main"}" && cd ../
@@ -201,19 +219,8 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    echo "Wait for lvm-llava service to be ready"
-    max_retries=10
-    for i in $(seq $max_retries)
-    do
-        lvm_logs=$(docker logs tgi-llava-gaudi-server 2>&1 | grep "Connected" || true)
-        if [[ -z "$lvm_logs" ]]; then
-            echo "The lvm-llava service is not ready yet, sleeping 30s..."
-            sleep 30s
-        else
-            echo "lvm-llava service is ready"
-            break
-        fi
-    done
+    echo "Wait for tgi-llava-gaudi-server service to be ready"
+    check_service_ready "tgi-llava-gaudi-server" 10 "Connected"
 
     if [[ $i -ge 10 ]]; then
         echo "WARNING: Max retries reached when waiting for the lvm-llava service to be ready"

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -34,6 +34,11 @@ function check_service_ready() {
             break
         fi
     done
+
+    if [[ $i -ge $max_retries ]]; then
+        echo "WARNING: Max retries reached when waiting for the $container_name service to be ready"
+        docker logs "$container_name" >> "${LOG_PATH}/$container_name_file.log"
+    fi
 }
 
 function build_docker_images() {
@@ -221,11 +226,6 @@ function validate_microservices() {
 
     echo "Wait for tgi-llava-gaudi-server service to be ready"
     check_service_ready "tgi-llava-gaudi-server" 10 "Connected"
-
-    if [[ $i -ge 10 ]]; then
-        echo "WARNING: Max retries reached when waiting for the lvm-llava service to be ready"
-        docker logs lvm-llava >> ${LOG_PATH}/lvm_llava_file.log
-    fi
 
     # llava server
     echo "Evaluating LLAVA tgi-gaudi"

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -203,8 +203,8 @@ function validate_microservices() {
     max_retries=10
     for i in $(seq $max_retries)
     do
-        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0")
-        if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
+        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://" || true)
+        if [[ -z "$lvm_logs" ]]; then
             echo "The lvm-llava service is not ready yet, sleeping 30s..."
             sleep 30s
         else

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -199,7 +199,24 @@ function validate_microservices() {
         "retriever-multimodal-redis" \
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
-    sleep 3m
+    echo "Wait for lvm-llava service to be ready"
+    max_retries=10
+    for i in $(seq $max_retries)
+    do
+        lvm_logs=$(docker logs lvm-llava 2>&1 | grep "Uvicorn running on http://0.0.0.0")
+        if [[ "$lvm_logs" != *"Uvicorn running on http://0.0.0.0"* ]]; then
+            echo "The lvm-llava service is not ready yet, sleeping 30s..."
+            sleep 30s
+        else
+            echo "lvm-llava service is ready"
+            break
+        fi
+    done
+
+    if [[ $i -ge 10 ]]; then
+        echo "WARNING: Max retries reached when waiting for the lvm-llava service to be ready"
+        docker logs lvm-llava >> ${LOG_PATH}/lvm_llava_file.log
+    fi
 
     # llava server
     echo "Evaluating lvm-llava"

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -34,6 +34,11 @@ function check_service_ready() {
             break
         fi
     done
+
+    if [[ $i -ge $max_retries ]]; then
+        echo "WARNING: Max retries reached when waiting for the $container_name service to be ready"
+        docker logs "$container_name" >> "${LOG_PATH}/$container_name_file.log"
+    fi
 }
 
 function build_docker_images() {


### PR DESCRIPTION
## Description

Poll the lvm-llava logs and wait until the service is running and able to respond to requests. This replaces a hard-coded 3m wait time.

## Issues

[Image_and_Audio_Support_in_MultimodalQnA RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

I successfully ran the modified `test_compose_on_xeon.sh`.