### PR TITLE
Fix dockerfile clone so it points to our branch

### DIFF
--- a/MultimodalQnA/Dockerfile
+++ b/MultimodalQnA/Dockerfile
@@ -14,7 +14,7 @@ RUN useradd -m -s /bin/bash user && \
 
 WORKDIR /home/user/
 #RUN git clone https://github.com/opea-project/GenAIComps.git
-RUN git clone https://github.com/mhbuehler/GenAIComps.git --single-branch --branch dina/image_query
+RUN git clone https://github.com/mhbuehler/GenAIComps.git --single-branch --branch mmqna-image-query
 
 WORKDIR /home/user/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \


### PR DESCRIPTION
## Description

The megaservice tests don't pass unless we are cloning the `mmqna-image-query` branch. We will undo this and point to the `main` branch before merging upstream.

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

I ran `test_compose_on_xeon.sh` to completion.
