### PR TITLE
Adds transcript to MMQnA conversation

### DIFF
--- a/MultimodalQnA/ui/gradio/conversation.py
+++ b/MultimodalQnA/ui/gradio/conversation.py
@@ -60,12 +60,12 @@ class Conversation:
                 for i, (role, message) in enumerate(messages):
                     if message:
                         dic = {"role": role}
+                        # The main message will be either audio or text
                         if self.audio_query_file:
                             content = [{"type": "audio", "audio": self.get_b64_audio_query()}]
-                        elif self.image:
-                            content = [{"type": "image_url", "image_url": {"url": self.image_query_file}}]
                         else:
                             content = [{"type": "text", "text": message}]
+                        # There might be a returned image/video from the first query
                         if i == 0 and self.time_of_frame_ms and self.video_file:
                             base64_frame = (
                                 self.base64_frame
@@ -74,9 +74,13 @@ class Conversation:
                             )
                             if base64_frame is None:
                                 base64_frame = ""
+                            # Include the original caption for the returned image/video
                             if self.caption and content[0]["type"] == "text":
                                 content[0]["text"] = content[0]["text"] + " " + self._template_caption()
                             content.append({"type": "image_url", "image_url": {"url": base64_frame}})
+                        # There might be a query image
+                        if self.image_query_file:
+                            content.append({"type": "image_url", "image_url": {"url": self.image_query_file}})
                         dic["content"] = content
                         conv_dict.append(dic)
             else:

--- a/MultimodalQnA/ui/gradio/conversation.py
+++ b/MultimodalQnA/ui/gradio/conversation.py
@@ -74,6 +74,8 @@ class Conversation:
                             )
                             if base64_frame is None:
                                 base64_frame = ""
+                            if self.caption and content[0]["type"] == "text":
+                                content[0]["text"] = content[0]["text"] + " " + self._template_caption()
                             content.append({"type": "image_url", "image_url": {"url": base64_frame}})
                         dic["content"] = content
                         conv_dict.append(dic)

--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -115,7 +115,8 @@ def http_bot(state, request: gr.Request):
         "messages": prompt,
     }
 
-    logger.info(f"==== request ====\n{pload}")
+    if logflag:
+        logger.info(f"==== request ====\n{pload}")
     logger.info(f"==== url request ====\n{gateway_addr}")
 
     state.messages[-1][-1] = "▌"

--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -148,6 +148,7 @@ def http_bot(state, request: gr.Request):
                 video_file = metadata["source_video"]
                 state.video_file = os.path.join(static_dir, metadata["source_video"])
                 state.time_of_frame_ms = metadata["time_of_frame_ms"]
+                state.caption = metadata["transcript_for_inference"]
                 file_ext = os.path.splitext(state.video_file)[-1]
                 if file_ext == ".mp4":
                     try:


### PR DESCRIPTION
## Description

This change adds the returned video's (or image's) transcript (or caption) to the conversation history so it remains in the persistent chat context until the user clears the history.

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

N/A

## Tests

Changes are in the UI only, so I manually tested.