### PR TITLE
Update compose.yaml to use fixed internal port for the whisper server

### DIFF
--- a/MultimodalQnA/docker_compose/intel/cpu/xeon/compose.yaml
+++ b/MultimodalQnA/docker_compose/intel/cpu/xeon/compose.yaml
@@ -6,13 +6,12 @@ services:
     image: ${REGISTRY:-opea}/whisper:${TAG:-latest}
     container_name: whisper-service
     ports:
-      - "${WHISPER_PORT}:${WHISPER_PORT}"
+      - "${WHISPER_PORT}:7066"
     ipc: host
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
-      WHISPER_PORT: ${WHISPER_PORT}
     restart: unless-stopped
   asr:
     image: ${REGISTRY:-opea}/asr:${TAG:-latest}


### PR DESCRIPTION
## Description

This PR is based on a comment made in the GenAIComps PR. We really only need the external port to be configurable. We can hold on merging this until we hear back to Melanie's comment in the PR.

## Issues

https://github.com/opea-project/GenAIComps/pull/1134#discussion_r1912621402

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

Tested by using a different port externally vs internally:

```
$ docker ps
33ca0dedbfef   opea/whisper:latest                            "python whisper_serv…"   7 minutes ago   Up 7 minutes             0.0.0.0:7044->7066/tcp                           whisper-service
...

$ echo $WHISPER_SERVER_ENDPOINT
http://10.165.116.7:7044/v1/asr

$ curl ${WHISPER_SERVER_ENDPOINT}     -X POST     -H "Content-Type: application/json"     -d '{"audio" : "UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA"}'
{"asr_result":"you"}
```
