### PR TITLE
Fixes omitted transcript when follow-up query for a PDF is in audio format

### DIFF
--- a/MultimodalQnA/ui/gradio/conversation.py
+++ b/MultimodalQnA/ui/gradio/conversation.py
@@ -68,12 +68,11 @@ class Conversation:
                 for i, (role, message) in enumerate(messages):
                     if message:
                         dic = {"role": role}
-                        # The main message will be either audio or text
+                        content = [{"type": "text", "text": message}]
+                        # There might be audio
                         if self.audio_query_file:
-                            content = [{"type": "audio", "audio": self.get_b64_audio_query()}]
-                        else:
-                            content = [{"type": "text", "text": message}]
-                        # There might be a returned image/video from the first query
+                            content.append({"type": "audio", "audio": self.get_b64_audio_query()})   
+                        # There might be a returned item from the first query
                         if i == 0 and self.time_of_frame_ms and self.video_file:
                             base64_frame = (
                                 self.base64_frame


### PR DESCRIPTION
## Description

This is a fix for an issue I spotted during testing where follow-up audio queries were not including the original transcript for the returned PDF image.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

UI testing
