### PR TITLE
Fix env vars in the MMQnA test environment and align_inputs error

### DIFF
--- a/MultimodalQnA/multimodalqna.py
+++ b/MultimodalQnA/multimodalqna.py
@@ -33,14 +33,18 @@ WHISPER_SERVER_ENDPOINT = os.getenv("WHISPER_SERVER_ENDPOINT", "http://0.0.0.0:$
 
 def align_inputs(self, inputs, cur_node, runtime_graph, llm_parameters_dict, **kwargs):
     if self.services[cur_node].service_type == ServiceType.EMBEDDING:
+        if "text" in inputs:
+            input_text = inputs["text"]["text"] if isinstance(inputs["text"], dict) else inputs["text"]
+        if "image" in inputs:
+            input_image = inputs["image"]["base64_image"] if isinstance(inputs["image"], dict) else inputs["image"]
         if "text" in inputs and "image" in inputs:
-            text_doc = TextDoc(text=inputs["text"])
-            image_doc = ImageDoc(base64_image=inputs["image"])
+            text_doc = TextDoc(text=input_text)
+            image_doc = ImageDoc(base64_image=input_image)
             inputs = TextImageDoc(text=text_doc, image=image_doc).dict()
         elif "image" in inputs:
-            inputs = ImageDoc(base64_image=inputs["image"]).dict()
+            inputs = ImageDoc(base64_image=input_image).dict()
         elif "text" in inputs:
-            inputs = TextDoc(text=inputs["text"]).dict()
+            inputs = TextDoc(text=input_text).dict()
     return inputs
 
 

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -81,7 +81,7 @@ function setup_env() {
     export EMM_BRIDGETOWER_PORT=6006
     export BRIDGE_TOWER_EMBEDDING=true
     export EMBEDDING_MODEL_ID="BridgeTower/bridgetower-large-itm-mlm-itc"
-    export MMEI_EMBEDDING_ENDPOINT="http://${host_ip}:$EMM_BRIDGETOWER_PORT/v1/encode"
+    export MMEI_EMBEDDING_ENDPOINT="http://${host_ip}:$EMM_BRIDGETOWER_PORT"
     export MM_EMBEDDING_PORT_MICROSERVICE=6000
     export REDIS_RETRIEVER_PORT=7000
     export LVM_PORT=9399

--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -68,6 +68,7 @@ function setup_env() {
     export WHISPER_PORT=7066
     export MAX_IMAGES=1
     export WHISPER_MODEL="base"
+    export WHISPER_SERVER_ENDPOINT="http://${host_ip}:${WHISPER_PORT}/v1/asr"
     export ASR_ENDPOINT=http://$host_ip:$WHISPER_PORT
     export ASR_PORT=9099
     export ASR_SERVICE_PORT=3001

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -79,7 +79,7 @@ function setup_env() {
     export EMM_BRIDGETOWER_PORT=6006
     export BRIDGE_TOWER_EMBEDDING=true
     export EMBEDDING_MODEL_ID="BridgeTower/bridgetower-large-itm-mlm-itc"
-    export MMEI_EMBEDDING_ENDPOINT="http://${host_ip}:$EMM_BRIDGETOWER_PORT/v1/encode"
+    export MMEI_EMBEDDING_ENDPOINT="http://${host_ip}:$EMM_BRIDGETOWER_PORT"
     export MM_EMBEDDING_PORT_MICROSERVICE=6000
     export REDIS_RETRIEVER_PORT=7000
     export LVM_PORT=9399

--- a/MultimodalQnA/tests/test_compose_on_xeon.sh
+++ b/MultimodalQnA/tests/test_compose_on_xeon.sh
@@ -61,6 +61,7 @@ function setup_env() {
     export WHISPER_PORT=7066
     export MAX_IMAGES=1
     export WHISPER_MODEL="base"
+    export WHISPER_SERVER_ENDPOINT="http://${host_ip}:${WHISPER_PORT}/v1/asr"
     export ASR_ENDPOINT=http://$host_ip:$WHISPER_PORT
     export ASR_PORT=9099
     export ASR_SERVICE_PORT=3001


### PR DESCRIPTION
## Description

Embedding service tests are failing because the `MMEI_EMBEDDING_ENDPOINT` path was incorrect so when the embedding service was trying to call the bridgetower service, it was internally getting a 404. As you can see [here](https://github.com/mhbuehler/GenAIComps/blob/mmqna-image-query/comps/embeddings/src/integrations/multimodal_bridgetower.py#L69), the `/v1/encode` part of the path is added later, so it shouldn't be part of the env var (otherwise it's double added). The `README.sh` and `set_env.sh` files already had the correct env var value.

The audio query test was failing due to `WHISPER_SERVER_ENDPOINT` missing.

Lastly, for image queries, `align_inputs` in multimodalqna.py was not supporting the format used for initial image queries (with dictionaries).

## Issues

Test failures in https://github.com/opea-project/GenAIExamples/pull/1381

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

Ran MMQnA test scripts