### PR TITLE
Increase timeout waiting the LVM to download in Gaudi MMQnA test

### DIFF
--- a/MultimodalQnA/tests/test_compose_on_gaudi.sh
+++ b/MultimodalQnA/tests/test_compose_on_gaudi.sh
@@ -252,7 +252,7 @@ function validate_microservices() {
         "{\"text\":\"test\",\"embedding\":${your_embedding}}"
 
     echo "Wait for tgi-llava-gaudi-server service to be ready"
-    check_service_ready "tgi-llava-gaudi-server" 10 "Connected"
+    check_service_ready "tgi-llava-gaudi-server" 20 "Connected"
 
     # llava server
     echo "Evaluating LLAVA tgi-gaudi"


### PR DESCRIPTION
## Description

This PR address a test failure due to a timeout waiting for the LVM when testing MMQnA on Gaudi.

## Issues

Test fails while waiting for the model to be ready:
```
Wait for tgi-llava-gaudi-server service to be ready
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
The tgi-llava-gaudi-server service is not ready yet, sleeping 30s...
WARNING: Max retries reached when waiting for the tgi-llava-gaudi-server service to be ready
Evaluating LLAVA tgi-gaudi
Error: Process completed with exit code 7.
```

https://github.com/opea-project/GenAIExamples/pull/1381

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

This is a test fix
