### PR TITLE
Enable audio caption upload in the UI

### DIFF
--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -525,7 +525,7 @@ with gr.Blocks() as upload_image:
     gr.Markdown("Use this interface to ingest an image and generate a caption for it. If uploading a caption, populate it before the image.")
 
     text_caption_label = "Text Caption"
-    audio_caption_label = "Voice Audio Caption"
+    audio_caption_label = "Voice Audio Caption ({}, or microphone)".format(", ".join(AUDIO_FORMATS))
     def select_upload_type(choice, request: gr.Request):
         if choice == "gen_caption":
             return (
@@ -552,7 +552,7 @@ with gr.Blocks() as upload_image:
     def verify_audio_caption_type(file, request: gr.Request):
         audio_type = os.path.splitext(file)[-1]
         if audio_type not in AUDIO_FORMATS:
-            raise Exception("The audio file format must be .wav or .mp3")
+            raise Exception('The audio file format must be {}'.format(" or ".join(AUDIO_FORMATS)))
         return file
 
     with gr.Row():

--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -316,8 +316,10 @@ def ingest_gen_caption(filepath, filetype, request: gr.Request):
     return
 
 
-def ingest_with_text(filepath, text, request: gr.Request):
+def ingest_with_caption(filepath, text_caption, audio_caption, request: gr.Request):
     yield (gr.Textbox(visible=True, value="Please wait for your uploaded image to be ingested into the database..."))
+
+    # Process the image
     verified_filepath = os.path.normpath(filepath)
     if not verified_filepath.startswith(tmp_upload_folder):
         print("Found malicious image file name!")
@@ -331,19 +333,29 @@ def ingest_with_text(filepath, text, request: gr.Request):
     basename = os.path.basename(verified_filepath)
     dest = os.path.join(static_dir, basename)
     shutil.copy(verified_filepath, dest)
-    text_basename = "{}.txt".format(os.path.splitext(basename)[0])
-    text_dest = os.path.join(static_dir, text_basename)
-    with open(text_dest, "w") as file:
-        file.write(text)
+
+    # Process the caption (can be text or audio)
+    is_audio_caption = audio_caption is not None
+    if is_audio_caption:
+        verified_audio_path = os.path.normpath(audio_caption)
+        caption_basename = "{}{}".format(os.path.splitext(basename)[0], os.path.splitext(verified_audio_path)[-1])
+        caption_file = audio_caption
+    else:
+        caption_basename = "{}.txt".format(os.path.splitext(basename)[0])
+        caption_file = os.path.join(static_dir, caption_basename)
+        with open(caption_file, "w") as file:
+            file.write(text_caption)
+
     print("Done copying uploaded files to static folder!")
     headers = {
         # 'Content-Type': 'multipart/form-data'
     }
-    files = [("files", (basename, open(dest, "rb"))), ("files", (text_basename, open(text_dest, "rb")))]
+    files = [("files", (basename, open(dest, "rb"))), ("files", (caption_basename, open(caption_file, "rb")))]
     try:
         response = requests.post(dataprep_ingest_addr, headers=headers, files=files)
     finally:
-        os.remove(text_dest)
+        if not is_audio_caption:
+            os.remove(caption_file)
     logger.info(response.status_code)
     if response.status_code == 200:
         response = response.json()
@@ -429,8 +441,8 @@ def hide_text(request: gr.Request):
     return gr.Textbox(visible=False)
 
 
-def clear_text(request: gr.Request):
-    return None
+def clear_captions(request: gr.Request):
+    return None, None
 
 
 def get_files():
@@ -507,13 +519,32 @@ with gr.Blocks() as upload_video:
 
 with gr.Blocks() as upload_image:
     gr.Markdown("# Ingest Images Using Generated or Custom Captions")
-    gr.Markdown("Use this interface to ingest an image and generate a caption for it")
+    gr.Markdown("Use this interface to ingest an image and generate a caption for it. If uploading a caption, populate it before the image.")
 
+    text_caption_label = "Text Caption"
+    audio_caption_label = "Voice Audio Caption"
     def select_upload_type(choice, request: gr.Request):
         if choice == "gen_caption":
-            return gr.Image(sources="upload", visible=True), gr.Image(sources="upload", visible=False)
+            return (
+                gr.Image(sources="upload", visible=True),
+                gr.Image(sources="upload", visible=False),
+                gr.Textbox(visible=False, interactive=True, label=text_caption_label),
+                gr.Audio(visible=False, type="filepath", label=audio_caption_label)
+            )
+        elif choice == "custom_caption":
+            return (
+                gr.Image(sources="upload", visible=False),
+                gr.Image(sources="upload", visible=True),
+                gr.Textbox(visible=True, interactive=True, label=text_caption_label),
+                gr.Audio(visible=False, type="filepath", label=audio_caption_label)
+            )
         else:
-            return gr.Image(sources="upload", visible=False), gr.Image(sources="upload", visible=True)
+            return (
+                gr.Image(sources="upload", visible=False),
+                gr.Image(sources="upload", visible=True),
+                gr.Textbox(visible=False, interactive=True, label=text_caption_label),
+                gr.Audio(visible=True, type="filepath", label=audio_caption_label)
+            )
 
     with gr.Row():
         with gr.Column(scale=6):
@@ -521,22 +552,33 @@ with gr.Blocks() as upload_image:
             image_upload_text = gr.Image(type="filepath", sources="upload", elem_id="image_upload_cap", visible=False)
         with gr.Column(scale=3):
             text_options_radio = gr.Radio(
-                [("Generate caption", "gen_caption"), ("Custom caption or label", "custom_caption")],
-                label="Text Options",
-                info="How should text be ingested?",
+                [
+                    ("Auto-generate a caption", "gen_caption"),
+                    ("Upload a text caption (populate before image)", "custom_caption"),
+                    ("Upload an audio caption (populate before image)", "custom_audio_caption")
+                ],
+                label="Caption Options",
+                info="How should captions be ingested?",
                 value="gen_caption",
             )
-            custom_caption = gr.Textbox(visible=True, interactive=True, label="Custom Caption or Label")
+            custom_caption = gr.Textbox(visible=False, interactive=True, label=text_caption_label)
+            custom_caption_audio = gr.Audio(visible=False, type="filepath", label=audio_caption_label)
             text_upload_result = gr.Textbox(visible=False, interactive=False, label="Upload Status")
         image_upload_cap.upload(
             ingest_gen_caption, [image_upload_cap, gr.Textbox(value="image", visible=False)], [text_upload_result]
         )
         image_upload_cap.clear(hide_text, [], [text_upload_result])
-        image_upload_text.upload(ingest_with_text, [image_upload_text, custom_caption], [text_upload_result]).then(
-            clear_text, [], [custom_caption]
-        )
+        image_upload_text.upload(
+            ingest_with_caption,
+            [image_upload_text, custom_caption, custom_caption_audio],
+            [text_upload_result]
+        ).then(clear_captions, [], [custom_caption, custom_caption_audio])
         image_upload_text.clear(hide_text, [], [text_upload_result])
-        text_options_radio.change(select_upload_type, [text_options_radio], [image_upload_cap, image_upload_text])
+        text_options_radio.change(
+            select_upload_type,
+            [text_options_radio],
+            [image_upload_cap, image_upload_text, custom_caption, custom_caption_audio]
+        )
 
 with gr.Blocks() as upload_audio:
     gr.Markdown("# Ingest Audio Using Generated Transcripts")

--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -552,8 +552,18 @@ with gr.Blocks() as upload_image:
     def verify_audio_caption_type(file, request: gr.Request):
         audio_type = os.path.splitext(file)[-1]
         if audio_type not in AUDIO_FORMATS:
-            raise Exception('The audio file format must be {}'.format(" or ".join(AUDIO_FORMATS)))
-        return file
+            return (
+                None,
+                gr.Textbox(
+                    visible=True,
+                    value="The audio file format must be {}".format(" or ".join(AUDIO_FORMATS))
+                )
+            )
+        else:
+            return (
+                gr.Audio(value=file, visible=True, type="filepath", label=audio_caption_label),
+                gr.Textbox(visible=False, value=None)
+            )
 
     with gr.Row():
         with gr.Column(scale=6):
@@ -573,7 +583,7 @@ with gr.Blocks() as upload_image:
             custom_caption = gr.Textbox(visible=False, interactive=True, label=text_caption_label)
             custom_caption_audio = gr.Audio(visible=False, type="filepath", label=audio_caption_label)
             text_upload_result = gr.Textbox(visible=False, interactive=False, label="Upload Status")
-        custom_caption_audio.input(verify_audio_caption_type, [custom_caption_audio], [custom_caption_audio])
+        custom_caption_audio.input(verify_audio_caption_type, [custom_caption_audio], [custom_caption_audio, text_upload_result])
         image_upload_cap.upload(
             ingest_gen_caption, [image_upload_cap, gr.Textbox(value="image", visible=False)], [text_upload_result]
         )


### PR DESCRIPTION
## Description

This change makes some improvements to the upload page for images and adds a radio button for audio captions (supports file upload and mic recording). I opted not to use the MultimodalTextbox, because disabling the built-in `send` button makes the uploaded files not visible, or they are not visible until submission. There may be a way to improve this with a future version of gradio, or when they provide more detailed documentation.

## Issues

[Issue](https://github.com/opea-project/GenAIExamples/issues/1549)
[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

N/A

## Tests

I tested by uploading different image types with different caption types (.wav, .mp3, and text) and found a bug when ingesting .jpg and .jpeg files (fixed by https://github.com/mhbuehler/GenAIComps/pull/29). I also tested lvm caption generation and found no regressions. I then made queries for the uploaded files and verified their captions are being referenced.
