### PR TITLE
PDF UI improvements

### DIFF
--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -444,6 +444,13 @@ def hide_text(request: gr.Request):
     return gr.Textbox(visible=False)
 
 
+def hide_text_pdf(pdf, text, request: gr.Request):
+    if pdf is not None:
+        return text
+    else:
+        return gr.Textbox(visible=False)
+
+
 def clear_captions(request: gr.Request):
     return None, None
 
@@ -624,6 +631,7 @@ with gr.Blocks() as upload_pdf:
             pdf_upload = PDF(label="PDF File")
         with gr.Column(scale=3):
             pdf_upload_result = gr.Textbox(visible=False, interactive=False, label="Upload Status")
+        pdf_upload.change(hide_text_pdf, [pdf_upload, pdf_upload_result], [pdf_upload_result])
         pdf_upload.upload(ingest_pdf, [pdf_upload], [pdf_upload_result])
 
 with gr.Blocks() as qna:

--- a/MultimodalQnA/ui/gradio/requirements.txt
+++ b/MultimodalQnA/ui/gradio/requirements.txt
@@ -1,5 +1,5 @@
 gradio==5.11.0
-gradio_pdf==0.0.19
+gradio_pdf==0.0.20
 moviepy==1.0.3
 numpy==1.26.4
 opencv-python==4.10.0.82


### PR DESCRIPTION
## Description

This PR:

1. Upgrades `gradio_pdf` to fix an issue with the Q&A pdf component (nonfunctional `interactive=False` property). Now, uploading from this tab will not be possible, but clearing with the `x` button still is.

1. Uses the `change` event to clear the status textbox when the ingest pdf component is empty. This produces the desired clearing behavior for the status textbox.

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

Upgrades `gradio_pdf` from `0.0.19` to `0.0.20`

## Tests

Manual UI tests
