### PR TITLE
MMQnA megaservice fix for trailing new line in first query prompts

### DIFF
--- a/MultimodalQnA/multimodalqna.py
+++ b/MultimodalQnA/multimodalqna.py
@@ -310,11 +310,11 @@ class MultimodalQnAService:
                 prompt = messages
                 initial_inputs = {"prompt": prompt, "image": ""}
         else:
-            # This is the first query. Ignore image input
+            # This is the first query.
             cur_megaservice = self.megaservice
             if isinstance(messages, tuple):
                 prompt, b64_types = messages
-                initial_inputs = {"text": prompt}
+                initial_inputs = {"text": prompt.rstrip("\n")}
                 if "audio" in b64_types:
                     # for metadata storage purposes
                     decoded_audio_input = b64_types["audio"]
@@ -323,7 +323,7 @@ class MultimodalQnAService:
                     initial_inputs["text"] = {"text": prompt}
                     initial_inputs["image"] = {"base64_image": b64_types["image"][0]}
             else:
-                initial_inputs = {"text": messages}
+                initial_inputs = {"text": messages.rstrip("\n")}
 
         parameters = LLMParams(
             max_new_tokens=chat_request.max_tokens if chat_request.max_tokens else 1024,


### PR DESCRIPTION
## Description

Harsha found that we didn't seem to be retrieving the right audio clip when sending a request like:
```
{"messages": [{"role": "user", "content": [{"type": "text", "text": "What is counterfactual reasoning?"}]}]}
```

When debugging the issue I found that when sending the request as a single string instead, it was getting the right audio clip:
```
{"messages": "What is counterfactual reasoning?"}
```

The recent UI updates make it so that now the messages are always sent as the list with roles, etc even when it's a first query. When comparing the backend mega service processing of the single string vs the single item in the list, I found the only difference to be a trailing "\n" that gets added to the prompt in `_handle_message` when `messages` is a list. This is because the `\n` end up being part of the prompt to the LVM and typically messages was a list means that we are going straight to the LVM instead of to the vector store.

Since the trailing `\n` is throwing off the accuracy of the retriever, this PR adds code to strip it off.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Tested with Harsha's audio context in the query window branch to verify that we are getting the related content.
