### PR TITLE
Specify MMQnA UI to use pydantic==2.10.6

### DIFF
--- a/MultimodalQnA/ui/gradio/requirements.txt
+++ b/MultimodalQnA/ui/gradio/requirements.txt
@@ -4,3 +4,5 @@ moviepy==1.0.3
 numpy==1.26.4
 opencv-python==4.10.0.82
 Pillow==10.3.0
+pydantic==2.10.6
+

--- a/MultimodalQnA/ui/gradio/requirements.txt
+++ b/MultimodalQnA/ui/gradio/requirements.txt
@@ -5,4 +5,3 @@ numpy==1.26.4
 opencv-python==4.10.0.82
 Pillow==10.3.0
 pydantic==2.10.6
-


### PR DESCRIPTION
## Description

The newest version of pydantic (2.11.0, released 5 hours ago) appears to be problematic with gradio (the UI won't even come up). Pegging to the previous release to pydantic resolves the issue. 

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

Pydantic was already brought in as a dependency by gradio, so this is not a new dependency.

## Tests

Manually built and tested UI container.
